### PR TITLE
Expand on command line functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM centurylink/ruby-base:2.1.2
+FROM ruby
 MAINTAINER Emre Demirors <emre.x.demirors@gmail.com>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get install -y git
-
 RUN gem install wmls
+RUN git clone https://github.com/wellstorm/wmls.git /root/wmls
 
-WORKDIR /root
-RUN git clone https://github.com/wellstorm/wmls.git
-ADD test_script.sh /root/test_script.sh
+WORKDIR /root/wmls
 
-CMD /bin/bash /root/test_script.sh 2>&1 | tee /var/log/run.log
+COPY run.sh /root/run.sh
+
+ENTRYPOINT ["/root/run.sh"]
+CMD ["query_v14/get_all_wells.xml", "-a", "get"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-This is the Docker file creates an image that can be used to automate tests for witsml store servers.
+WMLS
+====
+
+This is the Docker file creates an image that can be used to automate tests for [witsml] store servers.
 
 To use this Dockerfile, build the image and run it like so for automated tests:
-docker run -e WITSML_STORE_URL=storeurl -e WITSML_USER=username -e WITSML_PASSWORD=password wmlstest
+
+    docker run -e WITSML_STORE_URL=storeurl -e WITSML_USER=username -e WITSML_PASSWORD=password wmlstest
 
 Alternately, set the environment variables in the env file and run like so:
-docker run --env-file=env wmlstest
+
+    docker run --env-file=env wmlstest
+
+If you want to run custom XML queries:
+
+    docker run --env-file=env -v path/to/local/xmlfolder:/root/wmls/xmlfolder wmlstest xmlfolder/xmlfile --args
+
+[witsml]: http://www.energistics.org/drilling-completions-interventions/witsml-standards

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+wmls -r $WITSML_STORE_URL \
+    -t $WITSML_TIMEOUT \
+    -u $WITSML_USER \
+    -p $WITSML_PASS \
+    -q $@

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Add your tests here
-
-wmls -r $WITSML_STORE_URL -u $WITSML_USER -p $WITSML_PASS -t $WITSML_TIMEOUT -q /root/wmls/query_v14/get_all_wells.xml -a get


### PR DESCRIPTION
By allowing specific xml files to be passed, acts more as an isolated
process as opposed to a VM one would shell into.
